### PR TITLE
Remove line about contributing back to 3DMigoto from COPYING.txt

### DIFF
--- a/COPYING.txt
+++ b/COPYING.txt
@@ -1,6 +1,5 @@
 The source code of 3Dmigoto is released under the GPLv3 license - refer to
-LICENSE.GPL.txt for details. We ask that you consider contributing enhancements
-back to the 3Dmigoto project, but this is not strictly required.
+LICENSE.GPL.txt for details.
 
 Any shaders distributed along with 3Dmigoto as part of game fixes are not
 covered by the license of 3Dmigoto, and are owned by their respective copyright


### PR DESCRIPTION
The removed line was a leftover from when 3DMigoto used to be provided under the MIT license, and while it is technically still true under the GPLv3 (forks are required to publish their source code when they publish a binary release, but they are not necessarily required to contribute it back to 3DMigoto), it is unnecessary to state this here and may lead to confusion.